### PR TITLE
feat: agregar configuración del logger para registrar errores y eventos

### DIFF
--- a/Sistema_Gestion.py
+++ b/Sistema_Gestion.py
@@ -7,6 +7,19 @@
 # Daniel Eduardo Caro Rodriguez
 # Hugo Enrique Florez Granados
 #=======================================
+# CONFIGURACIÓN DEL LOGGER
+# Registra errores y eventos en un archivo .log
+
+
+os.makedirs("logs", exist_ok=True)
+
+logging.basicConfig(
+    filename="logs/sistema.log",
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    encoding="utf-8"
+)
+logger = logging.getLogger(__name__)
 class Cliente:  # Definición de la clase Cliente
 
     def __init__(self, nombre, edad, correo):  # Constructor que inicializa los atributos del cliente


### PR DESCRIPTION
## 📋 Descripción

Configura el sistema de logs profesional del proyecto usando el módulo `logging` 
de Python.

## ✨ Cambios incluidos

- Bloque de configuración del logger al inicio del archivo
- Creación automática de la carpeta `logs/` si no existe (`os.makedirs`)
- Archivo de salida: `logs/sistema.log` (en lugar de `logs.txt` plano)
- Formato profesional con timestamp, nivel y mensaje:  
  `2026-04-27 18:45:12 - ERROR - mensaje del evento`
- Niveles disponibles: `INFO`, `WARNING`, `ERROR`

## 🎯 ¿Por qué este cambio?

- El README ya documenta que los logs van en `logs/sistema.log`, así que ahora 
  el código coincide con la documentación
- Aprovecha los imports `os` y `logging` que ya estaban en `main` pero que 
  ningún módulo estaba usando
- Habilita que las próximas ramas (`excepciones`, `entidadbase`, `servicio-sala`) 
  usen un logger unificado en lugar de cada una escribir el log a su manera

## 🔗 Issue relacionado
Closes #2 