### PR TITLE
fix: corregir AlquilerEquipo y control de estado en Reserva.confirmar()

### DIFF
--- a/Sistema_Gestion.py
+++ b/Sistema_Gestion.py
@@ -270,7 +270,9 @@ class AlquilerEquipo(Servicio):
     def describir(self) -> str:
         return (f"Equipo '{self._nombre}' ({self.__tipo_equipo}) "
 
-                f"| Precio: ${self._precio_hora}/h | Depósito: ${self.__deposito}")
+                f"| Precio: ${self._precio_base}/h | Depósito: ${self.__deposito}")
+    def validar(self) -> bool:
+        return True
 # =============================
 # CLASE ASESORIA ESPECIALIZADA
 # =============================
@@ -370,8 +372,8 @@ class Reserva(EntidadSistema):
     def confirmar(self):
        
         # No se puede confirmar una reserva cancelada
-        if self._estado == "cancelada":
-            raise ReservaError("No se puede confirmar una reserva cancelada")
+        if self._estado in ["cancelada", "procesada", "confirmada"]:
+            raise ReservaError(f"No se puede confirmar una reserva en estado '{self._estado}'")
 
         # Se verifica disponibilidad del servicio
         if not self._servicio.esta_disponible():


### PR DESCRIPTION
Se corrigen 3 errores que impedían el funcionamiento completo del sistema:

- AlquilerEquipo: se agrega método validar() que faltaba por ser abstracto en EntidadSistema. Sin él, Python lanza TypeError al intentar instanciar cualquier objeto AlquilerEquipo.

- AlquilerEquipo.describir(): se reemplaza self._precio_hora por self._precio_base, que es el nombre real del atributo definido en Servicio. _precio_hora nunca existió.

- Reserva.confirmar(): se amplía la condición de bloqueo para incluir estados 'procesada' y 'confirmada', no solo 'cancelada'. Sin esto una reserva procesada podía volver a confirmarse.

Closes errores detectados en revisión del archivo reorganizado.