### PR TITLE
fix: agregar getter get_estado() en clase Reserva

### DIFF
--- a/Sistema_Gestion.py
+++ b/Sistema_Gestion.py
@@ -365,7 +365,8 @@ class Reserva(EntidadSistema):
 
         # Registro en logs
         logger.info("Reserva creada correctamente")
-
+    def get_estado(self): # Método getter para obtener el estado actual de la reserva
+        return self._estado # Retorna el estado actual de la reserva, que puede ser "pendiente", "confirmada", "procesada" o "cancelada". 
     # ==========================
     # CONFIRMAR RESERVA
     # ==========================


### PR DESCRIPTION
SistemaGestion.listar_reservas_por_estado() llama r.get_estado() pero el método no existía en Reserva, lo que generaba AttributeError al intentar filtrar reservas por estado.

Se agrega el getter get_estado() que retorna self._estado, consistente con el patrón de encapsulación del resto de la clase.

Línea agregada después de __init__():
    def get_estado(self):
        return self._estado